### PR TITLE
Document new `extraObjects` field in Helm chart

### DIFF
--- a/content/configuration/helm-options.md
+++ b/content/configuration/helm-options.md
@@ -120,3 +120,4 @@ serviceAccount:
 | serviceMonitor.path | string | `"/metrics"` |  |
 | serviceMonitor.port | string | `"metrics"` |  |
 | tolerations | list | `[]` |  |
+| extraObjects | list | `[]` | Extra Kubernetes resources to create. Helm templating is allowed as it is evaluated before creating the resources. |


### PR DESCRIPTION
##### SUMMARY

- Document new `extraObjects` field in Helm chart

This PR synchronizes the Botkube Helm chart Readme.

See https://github.com/infracloudio/botkube/pull/578 for details.

Resolves https://github.com/infracloudio/botkube/issues/561
