### PR TITLE
Build website with Hugo 0.98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Generated files by hugo
+/public/
+/resources/_gen/
+/assets/jsconfig.json
+hugo_stats.json
+
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux
+
+# Temporary lock file while building
+/.hugo_build.lock

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ more details).
 
 ### Build the site locally
 Make sure you have installed
-[Hugo](https://gohugo.io/getting-started/installing/) on your
+[Hugo](https://gohugo.io) 0.98.0 on your
 system. Follow the instructions to clone this repository and build the
 docs locally.
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,7 +14,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     {{ partial "meta.html" . }}
     {{ partial "favicon.html" . }}
     {{ template "_internal/twitter_cards.html" . }}
@@ -114,7 +114,7 @@
         {{define "breadcrumb"}}
           {{$parent := .page.Parent }}
           {{ if $parent }}
-            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.URL $parent.Title .value) }}
+            {{ $value := (printf "<a href='%s'>%s</a> > %s" $parent.RelPermalink $parent.Title .value) }}
             {{ template "breadcrumb" dict "page" $parent "value" $value }} 
           {{else}}
             {{.value|safeHTML}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.92.2"
+HUGO_VERSION = "0.98.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo  --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.92.2"
+HUGO_VERSION = "0.98.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo  --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.92.2"
+HUGO_VERSION = "0.98.0"
 
 [context.branch-deploy]
 command = "hugo  --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.92.2"
+HUGO_VERSION = "0.98.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
##### SUMMARY

- Update Hugo version used for build
- Update usage of already removed Hugo API
- Add gitignore

As a part of https://github.com/infracloudio/botkube-docs/pull/72 I saw that the docs website doesn't use the latest Hugo, so I updated the API and Netlify build versions.