### PR TITLE
Fix helm install, minor fixes to all installation docs

### DIFF
--- a/content/installation/Discord/_index.md
+++ b/content/installation/Discord/_index.md
@@ -45,7 +45,7 @@ Follow the steps below to install BotKube Discord app to your Discord server.
     ![discord_bot_scope](/images/discord_bot_scope.png)
 
     the generated URL contains **YOUR_CLIENT_ID**, Scope and permission details.
-    
+
     ```
     https://discord.com/api/oauth2/authorize?client_id=<YOUR_CLIENT_ID>&permissions=<SET_OF_PERMISSIONS>&scope=bot
     ```
@@ -84,17 +84,17 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
 #### Using helm
 
 - We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
-- Add **infracloudio** chart repository
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.discord.enabled=true \
   --set communications.discord.channel=<DISCORD_CHANNEL_ID> \
   --set communications.discord.botid=<DISCORD_BOT_ID> \
@@ -127,11 +127,11 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -161,11 +161,11 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
         - spec.template.spec.containers[*].image
         - status.conditions[*].type
     ```
-  - Pass the yaml file as a flag to `helm install` command.
+  - Pass the YAML file as a flag to `helm install` command.
     e.g
 
     ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -173,30 +173,30 @@ Follow the first 4 mins of this [Video Tutorial](https://youtu.be/8o25pRbXdFw) t
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to Kubernetes cluster.
+- Download deployment specs YAML:
 
-```bash
-$ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
-```
+  ```bash
+  $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
+  ```
 
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
-Set *DISCORD_ENABLED*, *DISCORD_BOTID*,  *DISCORD_CHANNEL*, *DISCORD_TOKEN*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *DISCORD_ENABLED*, *DISCORD_BOTID*,  *DISCORD_CHANNEL*, *DISCORD_TOKEN*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
-  - **DISCORD_CHANNEL_ID** is the channel name where @BotKube needs to send notifications<br>
-  - **DISCORD_BOT_ID** is the BotKube Application Client ID<br>
-  - **DISCORD_TOKEN** is the Token you received after adding BotKube bot to your Discord Application<br>
-  - **CLUSTER_NAME** is the cluster name set in the incoming messages<br>
-  - **ALLOW_KUBECTL** set true to allow kubectl command execution by BotKube on the cluster<br>
+  where,<br>
+    - **DISCORD_CHANNEL_ID** is the channel name where @BotKube needs to send notifications<br>
+    - **DISCORD_BOT_ID** is the BotKube Application Client ID<br>
+    - **DISCORD_TOKEN** is the Token you received after adding BotKube bot to your Discord Application<br>
+    - **CLUSTER_NAME** is the cluster name set in the incoming messages<br>
+    - **ALLOW_KUBECTL** set true to allow kubectl command execution by BotKube on the cluster<br>
 
-Configuration syntax is explained [here](/configuration).
+  Configuration syntax is explained [here](/configuration).
 
-- Deploy the resources
+- Deploy the resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 - Check pod status in botkube namespace. Once running, send **@BotKube ping** in the Discord channel to confirm if BotKube is responding correctly.
 

--- a/content/installation/ElasticSearch/_index.md
+++ b/content/installation/ElasticSearch/_index.md
@@ -9,18 +9,18 @@ toc = true
 
 #### Using helm
 
-- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already
-- Add **infracloudio** chart repository
+- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster.
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.elasticsearch.enabled=true \
   --set communications.elasticsearch.server=<ELASTICSEARCH_ADDRESS> \
   --set communications.elasticsearch.username=<ELASTICSEARCH_USERNAME> \
@@ -57,11 +57,11 @@ toc = true
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -91,11 +91,10 @@ toc = true
         - spec.template.spec.containers[*].image
         - status.conditions[*].type
   ```
-  - Pass the yaml file as a flag to `helm install` command.
-    e.g
+  - Pass the YAML file as a flag to `helm install` command, e.g.:
 
-    ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    ```bash
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -103,27 +102,27 @@ toc = true
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to Kubernetes cluster.
+- Download deployment specs YAML:
 
-```bash
-$ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
-```
+  ```bash
+  $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
+  ```
 
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
 
-Set *ELASTICSEARCH_ENABLED*=true, *ELASTICSEARCH_USERNAME*, *ELASTICSEARCH_PASSWORD*, *clustername*, index settings and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *ELASTICSEARCH_ENABLED*=true, *ELASTICSEARCH_USERNAME*, *ELASTICSEARCH_PASSWORD*, *clustername*, index settings and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
-- **ELASTICSEARCH_ADDRESS** is an address on which ElasticSearch server is reachable e.g https://example.com:9243 <br>
-- **ELASTICSEARCH_USERNAME** is the username for authentication to Els server<br>
-- **ELASTICSEARCH_PASSWORD** is a password for the username to authenticate with Els server<br>
+  where,<br>
+  - **ELASTICSEARCH_ADDRESS** is an address on which ElasticSearch server is reachable e.g https://example.com:9243 <br>
+  - **ELASTICSEARCH_USERNAME** is the username for authentication to Els server<br>
+  - **ELASTICSEARCH_PASSWORD** is a password for the username to authenticate with Els server<br>
 
-- Create **botkube** namespace and deploy resources
+- Create **botkube** namespace and deploy resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 - Check pod status in botkube namespace.
 

--- a/content/installation/Mattermost/_index.md
+++ b/content/installation/Mattermost/_index.md
@@ -43,14 +43,14 @@ Add BotKube user created to the channel you want to receive notifications in.
 
 **2.** Click **Add Slash Command** and add the following details for the command and click **Save**.
 
-Field | Value
---- | ---
-Title | BotKube 
-Description | Show BotKube help
-Command Trigger Word | botkubehelp
-Request URL | https://botkube.herokuapp.com/help
-Request Method | POST
-Autocomplete | True
+| Field                | Value                              |
+|----------------------|------------------------------------|
+| Title                | BotKube                            |
+| Description          | Show BotKube help                  |
+| Command Trigger Word | botkubehelp                        |
+| Request URL          | https://botkube.herokuapp.com/help |
+| Request Method       | POST                               |
+| Autocomplete         | True                               |
 
 ![mm_botkube_slash_cmd](/images/mm_botkube_slash_cmd.png)
 
@@ -63,18 +63,18 @@ Autocomplete | True
 
 #### BotKube install: Using helm
 
-- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already
-- Add **infracloudio** chart repository
+- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster.
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.mattermost.enabled=true \
   --set communications.mattermost.url=<MATTERMOST_SERVER_URL> \
   --set communications.mattermost.cert=<MATTERMOST_CERT> \
@@ -115,11 +115,11 @@ Autocomplete | True
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -149,11 +149,10 @@ Autocomplete | True
         - spec.template.spec.containers[*].image
         - status.conditions[*].type
   ```
-  - Pass the yaml file as a flag to `helm install` command.
-    e.g
+  - Pass the YAML file as a flag to `helm install` command, e.g.:
 
-    ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    ```bash
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -161,40 +160,40 @@ Autocomplete | True
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to Kubernetes cluster.
+- Download deployment specs YAML:
 
-```bash
-$ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
-```
+  ```bash
+  $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
+  ```
 
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
-Set *MATTERMOST_ENABLED*, *MATTERMOST_SERVER_URL*, *MATTERMOST_TOKEN*, *MATTERMOST_TEAM*, *MATTERMOST_CHANNEL*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *MATTERMOST_ENABLED*, *MATTERMOST_SERVER_URL*, *MATTERMOST_TOKEN*, *MATTERMOST_TEAM*, *MATTERMOST_CHANNEL*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
-- **MATTERMOST_ENABLED** set true to enable Mattermost support for BotKube<br>
-- **MATTERMOST_SERVER_URL** is the URL where Mattermost is running<br>
-- **MATTERMOST_TOKEN** is the Token received by creating Personal Access Token for BotKube user<br>
-- **MATTERMOST_TEAM** is the Team name where BotKube is added<br>
-- **MATTERMOST_CHANNEL** is the Channel name where BotKube is added and used for communication<br>
-- **clustername** is the cluster name set in the incoming messages<br>
-- **kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
+  where,<br>
+  - **MATTERMOST_ENABLED** set true to enable Mattermost support for BotKube<br>
+  - **MATTERMOST_SERVER_URL** is the URL where Mattermost is running<br>
+  - **MATTERMOST_TOKEN** is the Token received by creating Personal Access Token for BotKube user<br>
+  - **MATTERMOST_TEAM** is the Team name where BotKube is added<br>
+  - **MATTERMOST_CHANNEL** is the Channel name where BotKube is added and used for communication<br>
+  - **clustername** is the cluster name set in the incoming messages<br>
+  - **kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
 
-   Configuration syntax is explained [here](/configuration).
+     Configuration syntax is explained [here](/configuration).
 
-- Deploy the resources
+- Deploy the resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 - Check pod status in botkube namespace. Once running, send **@BotKube ping** in the configured channel to confirm if BotKube is responding correctly.
 
 - To deploy with TLS, download and use deploy-all-in-one-tls.yaml. Replace **ENCODED_CERTIFICATE** with your base64 encoded certificate value in the secret. To get a base64 encoded value of your certificate, use below command and replace <YOUR_CERTIFICATE> with the certificate name.
 
-```bash
-$ cat <YOUR_CERTIFICATE> | base64 -w 0 
-```
+  ```bash
+  $ cat <YOUR_CERTIFICATE> | base64 -w 0
+  ```
 
 ### Remove BotKube from Mattermost Team
 

--- a/content/installation/Slack/_index.md
+++ b/content/installation/Slack/_index.md
@@ -28,18 +28,18 @@ After installing BotKube app to your Slack workspace, you could see a new bot us
 
 #### Using helm
 
-- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already
-- Add **infracloudio** chart repository
+- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster.
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.slack.enabled=true \
   --set communications.slack.channel=<SLACK_CHANNEL_NAME> \
   --set communications.slack.token=<SLACK_API_TOKEN_FOR_THE_BOT> \
@@ -70,11 +70,11 @@ After installing BotKube app to your Slack workspace, you could see a new bot us
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -104,11 +104,10 @@ After installing BotKube app to your Slack workspace, you could see a new bot us
         - spec.template.spec.containers[*].image
         - status.conditions[*].type
     ```
-  - Pass the yaml file as a flag to `helm install` command.
-    e.g
+  - Pass the YAML file as a flag to `helm install` command, e.g.:
 
-    ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    ```bash
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -116,30 +115,30 @@ After installing BotKube app to your Slack workspace, you could see a new bot us
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to Kubernetes cluster.
+- Download deployment specs YAML:
 
-```bash
-$ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
-```
+  ```bash
+  $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
+  ```
 
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
-Set *SLACK_ENABLED*, *SLACK_CHANNEL*, *SLACK_API_TOKEN*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *SLACK_ENABLED*, *SLACK_CHANNEL*, *SLACK_API_TOKEN*, *clustername*, *kubectl.enabled* and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
-- **SLACK_ENABLED** set true to enable Slack support for BotKube<br>
-- **SLACK_CHANNEL** is the channel name where @BotKube is added<br>
-- **SLACK_API_TOKEN** is the Token you received after installing BotKube app to your Slack workspace<br>
-- **clustername** is the cluster name set in the incoming messages<br>
-- **kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
+  where,<br>
+  - **SLACK_ENABLED** set true to enable Slack support for BotKube<br>
+  - **SLACK_CHANNEL** is the channel name where @BotKube is added<br>
+  - **SLACK_API_TOKEN** is the Token you received after installing BotKube app to your Slack workspace<br>
+  - **clustername** is the cluster name set in the incoming messages<br>
+  - **kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
 
-   Configuration syntax is explained [here](/configuration).
+     Configuration syntax is explained [here](/configuration).
 
-- Deploy the resources
+- Deploy the resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 - Check pod status in botkube namespace. Once running, send **@BotKube ping** in the Slack channel to confirm if BotKube is responding correctly.
 

--- a/content/installation/Teams/_index.md
+++ b/content/installation/Teams/_index.md
@@ -35,18 +35,18 @@ We will use "App Studio" to register and install Bot to MS Teams. Please follow 
 
 3. Fill in the App details
 
-    | Field      | Value |
-    | ---------- | -------- |
-    | Short name | BotKube     |
-    | Package name | botkube.io |
-    | App ID       | \<Click on Generate\> |
-    | Version      | 0.11.0 |
-    | Short Description | BotKube is a bot for your Kubernetes cluster |
-    | Full Description | App that helps you monitor your Kubernetes cluster, debug critical deployments & gives recommendations for standard practices. |
-    | Developer/Company Name | BotKube |
-    | Website    | https://botkube.io |
-    | Privacy statement | https://botkube.io/privacy |
-    | Terms of use    | https://botkube.io/license |
+    | Field                  | Value                                                                                                                          |
+    |------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+    | Short name             | BotKube                                                                                                                        |
+    | Package name           | botkube.io                                                                                                                     |
+    | App ID                 | \<Click on Generate\>                                                                                                          |
+    | Version                | 0.11.0                                                                                                                         |
+    | Short Description      | BotKube is a bot for your Kubernetes cluster                                                                                   |
+    | Full Description       | App that helps you monitor your Kubernetes cluster, debug critical deployments & gives recommendations for standard practices. |
+    | Developer/Company Name | BotKube                                                                                                                        |
+    | Website                | https://botkube.io                                                                                                             |
+    | Privacy statement      | https://botkube.io/privacy                                                                                                     |
+    | Terms of use           | https://botkube.io/license                                                                                                     |
 
     Click the checkbox on "Loading indicator" (optional)
 
@@ -64,7 +64,7 @@ Go to Capabilities > Bots and fill in the info
     - Scope: **[x] Personal** & **[x] Team**
     And Create bot.
 
-3. On the "Bots" page, click on **Generate a new password**. Note down the password required while installing BotKube backend. 
+3. On the "Bots" page, click on **Generate a new password**. Note down the password required while installing BotKube backend.
 
 4. **Copy App ID displayed below Bot name in the heading. Note that Bot App ID is different than the one we generate on the "Apps Details" page.**
 
@@ -98,27 +98,28 @@ Now there are few different ways to enable access to the K8s Service from the ou
 
 If you are new to Ingress and don't know how to set up an ingress controller, please follow [this](https://www.infracloud.io/blogs/deep-dive-ingress-kubernetes/) blog by InfraCloud.
 
-Create a K8s TLS secret from cert and key for the SSL termination in botkube namespace
+Create a K8s TLS secret from cert and key for the SSL termination in botkube namespace:
 
 ```bash
+$ kubectl create namespace botkube
 $ kubectl create secret tls botkube-tls -n botkube --cert=/path/to/cert.pem --key=/path/to/privatekey.pem
 ```
 We will use this TLS secret while deploying the BotKube backend.
 
 #### Using helm
 
-- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already
-- Add **infracloudio** chart repository
+- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster.
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace\
   --set communications.teams.enabled=true \
   --set communications.teams.appID=<APPLICATION_ID> \
   --set communications.teams.appPassword=<APPLICATION_PASSWORD> \
@@ -155,11 +156,11 @@ We will use this TLS secret while deploying the BotKube backend.
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```bash
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -190,11 +191,10 @@ We will use this TLS secret while deploying the BotKube backend.
         - status.conditions[*].type
   ```
 
-  - Pass the yaml file as a flag to `helm install` command.
-    e.g
+  - Pass the YAML file as a flag to `helm install` command, e.g.:
 
-    ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    ```bash
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -202,38 +202,35 @@ We will use this TLS secret while deploying the BotKube backend.
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to the Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to the Kubernetes cluster.
+- Download deployment specs YAML:
 
     ```bash
     $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
     ```
 - Uncomment BotKube service and ingress resource manifest.<br>
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
-Set *teams.enabled*, *APPLICATION_ID*, *APPLICATION_PASSWORD*, *HOST*, *URLPATH*, *TLS_SECRET_NAME* and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *teams.enabled*, *APPLICATION_ID*, *APPLICATION_PASSWORD*, *HOST*, *URLPATH*, *TLS_SECRET_NAME* and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
+  where,<br>
 
-- **communications.teams.enabled** set true to enable Teams support for BotKube<br>
-- **APPLICATION_ID** is the BotKube application ID generated while registering Bot to Teams<br>
-- **APPLICATION_PASSWORD** is the BotKube application password generated while registering Bot to Teams<br>
-- **HOST** is the Hostname of endpoint provided while registering BotKube to Teams<br>
-- **URLPATH** is the path in endpoint URL provided while registering BotKube to Teams<br>
-- **TLS_SECRET_NAME** is the K8s TLS secret name for the SSL termination<br>
-- **settings.clustername** is the cluster name set in the incoming messages<br>
-- **settings.kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
+  - **communications.teams.enabled** set true to enable Teams support for BotKube<br>
+  - **APPLICATION_ID** is the BotKube application ID generated while registering Bot to Teams<br>
+  - **APPLICATION_PASSWORD** is the BotKube application password generated while registering Bot to Teams<br>
+  - **HOST** is the Hostname of endpoint provided while registering BotKube to Teams<br>
+  - **URLPATH** is the path in endpoint URL provided while registering BotKube to Teams<br>
+  - **TLS_SECRET_NAME** is the K8s TLS secret name for the SSL termination<br>
+  - **settings.clustername** is the cluster name set in the incoming messages<br>
+  - **settings.kubectl.enabled** set true to allow kubectl command execution by BotKube on the cluster<br>
 
-   Configuration syntax is explained [here](/configuration).
-   Complete list of helm options is documented [here](/configuration/helm-options)
+     Configuration syntax is explained [here](/configuration).
+     Complete list of helm options is documented [here](/configuration/helm-options)
 
-- Deploy the resources
+- Deploy the resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
-
-
-
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 #### Verify if BotKube endpoint is reachable
 

--- a/content/installation/Webhook/_index.md
+++ b/content/installation/Webhook/_index.md
@@ -11,18 +11,18 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 
 #### Using helm
 
-- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already
-- Add **infracloudio** chart repository
+- We will be using [helm](https://helm.sh/) to install BotKube in Kubernetes. Follow [this](https://docs.helm.sh/using_helm/#installing-helm) guide to install helm if you don't have it installed already.
+- Add **infracloudio** chart repository:
 
   ```bash
   $ helm repo add infracloudio https://infracloudio.github.io/charts
   $ helm repo update
   ```
 
-- Deploy BotKube backend using **helm install** in your cluster.
+- Deploy BotKube backend using **helm install** in your cluster:
 
   ```bash
-  $ helm install --version v0.12.4 botkube --namespace botkube \
+  $ helm install --version v0.12.4 botkube --namespace botkube --create-namespace \
   --set communications.webhook.enabled=true \
   --set communications.webhook.url=<WEBHOOK_URL> \
   --set config.settings.clustername=<CLUSTER_NAME> \
@@ -47,11 +47,11 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 
     (You can refer sample config from https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/helm/botkube/sample-res-config.yaml)
 
-  ```
+  ```yaml
   config:
     ## Resources you want to watch
     resources:
-    - name: v1/pods        # Name of the resource. Resource name must be in 
+    - name: v1/pods        # Name of the resource. Resource name must be in
                            # group/version/resource (G/V/R) format
                            # resource name should be plural
                            # (e.g apps/v1/deployments, v1/pods)
@@ -81,11 +81,10 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
         - spec.template.spec.containers[*].image
         - status.conditions[*].type
   ```
-  - Pass the yaml file as a flag to `helm install` command.
-    e.g
+  - Pass the YAML file as a flag to `helm install` command, e.g.:
 
-    ```
-    $ helm install --version v0.12.4 --name botkube --namespace botkube -f /path/to/config.yaml --set=...other args..
+    ```bash
+    $ helm install --version v0.12.4 --name botkube --namespace botkube --create-namespace -f /path/to/config.yaml --set=...other args..
     ```
 
   Alternatively, you can also update the configuration at runtime as documented [here](/configuration/#updating-the-configuration-at-runtime)
@@ -93,26 +92,26 @@ BotKube can be integrated with external apps via Webhooks. A webhook is essentia
 
 #### Using kubectl
 
-- Make sure that you have kubectl cli installed and have access to Kubernetes cluster
-- Download deployment specs yaml
+- Make sure that you have kubectl cli installed and have access to Kubernetes cluster.
+- Download deployment specs YAML:
 
-```bash
-$ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
-```
+  ```bash
+  $ wget -q https://raw.githubusercontent.com/infracloudio/botkube/v0.12.4/deploy-all-in-one.yaml
+  ```
 
 - Open downloaded **deploy-all-in-one.yaml** and update the configuration.<br>
 
-Set *WEBHOOK_ENABLED*=true, *WEBHOOK_URL*, *clustername* and update the resource events configuration you want to receive notifications for in the configmap.<br>
+  Set *WEBHOOK_ENABLED*=true, *WEBHOOK_URL*, *clustername* and update the resource events configuration you want to receive notifications for in the configmap.<br>
 
-where,<br>
-- **WEBHOOK_URL** is an outgoing webook URL to which BotKube will POST the events <br>
-- **CLUSTER_NAME** is the cluster name set in the incoming messages<br>
+  where,<br>
+  - **WEBHOOK_URL** is an outgoing webook URL to which BotKube will POST the events <br>
+  - **CLUSTER_NAME** is the cluster name set in the incoming messages<br>
 
-- Deploy the resources
+- Deploy the resources:
 
-```bash
-$ kubectl create -f deploy-all-in-one.yaml
-```
+  ```bash
+  $ kubectl create -f deploy-all-in-one.yaml
+  ```
 
 - Check pod status in botkube namespace.
 

--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -13,12 +13,12 @@ BotKube has two components that need to be installed.
 
 #### Feature map
 
-| Feature  | Slack | Mattermost | Microsoft Teams | Discord | Elastic Search | Webhook |
-| -------- | ----- | -----------| --------------- | -------------- | ------- | ------- |
-| K8s Event push | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Kubectl commands | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | NA | NA |
-| Multi cluster support | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Restrict command execution to a channel | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | NA | NA |
+| Feature                                 | Slack              | Mattermost         | Microsoft Teams    | Discord            | Elastic Search     | Webhook            |
+|-----------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| K8s Event push                          | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Kubectl commands                        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | NA                 | NA                 |
+| Multi cluster support                   | :heavy_check_mark: | :heavy_check_mark: | :x:                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Restrict command execution to a channel | :heavy_check_mark: | :heavy_check_mark: | :x:                | :heavy_check_mark: | NA                 | NA                 |
 
 {{< raw_html >}}
 <style>


### PR DESCRIPTION
##### SUMMARY

- Fix helm install. Currently, the `helm install` requires the `botkube` Namespace to be created up-front, which is not described in doc. 

    However, the `helm install` has a flag to simplify this:
    ```bash
      --create-namespace                           create the release namespace if not present
    ```
- Minor format fixes to all installation docs to make it more readable.